### PR TITLE
[v0.13.2] [proguard] fixed issues with dropped themis symbols ==> master

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,22 @@ Do not commit binaries and artefacts to your repo
 * Carthage directory binary contents
 *  *.aar packages
 
+## Known issues
+
+Build artefact optimizer of Xamarin.Forms or Xamarin.Android might strip native Java classes from the binding lib
+For example:
+```
+Java.Lang.IncompatibleClassChangeError: no non-static method "Lcom/cossacklabs/themis/SecureCellSeal;.decrypt([B[B)[B"
+[orion.mobile]   at Java.Interop.JniEnvironment+InstanceMethods.GetMethodID (Java.Interop.JniObjectReference type, System.String name, System.String signature) [0x0005b] in <42d2b7086f0a46efb99253c5db1ecca9>:0 
+[orion.mobile]   at Android.Runtime.JNIEnv.GetMethodID (System.IntPtr kls, System.String name, System.String signature) [0x00007] in <3080427739614e60a939a88bf3f838d5>:0 
+[orion.mobile]   at Com.Cossacklabs.Themis.SecureCell+ISealInvoker.Decrypt (System.Byte[] p0, System.Byte[] p1) [0x00017] in <cd618986d1ce4194b63cdd3366dad291>:0 
+[orion.mobile]   at Themis.Droid.CellSealDroid.UnwrapData (Themis.ISecureCellData cipherTextData, System.Byte[] context) [0x0007e] in <a492e7118e094c3296442a386fe5d80e>:0 
+[orion.mobile]    --- End of inner exception stack trace ---
+```
+
+Most relevant resources for troubleshooting found so far:
+* https://gist.github.com/JonDouglas/dda6d8ace7d071b0e8cb
+* https://stackoverflow.com/questions/38967851/missing-methods-and-classes-in-jar-after-building-xamarin-app
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This repository is experimental and is not supported by [cossacklabs](https://www.cossacklabs.com/), authors of [themis](https://github.com/cossacklabs/themis/)
+
 The project depends on `themis` library binaries.
 The version has been pinned to `v0.13.2`.
 
@@ -37,7 +39,19 @@ Do not commit binaries and artefacts to your repo
 
 ## Known issues
 
-Build artefact optimizer of Xamarin.Forms or Xamarin.Android might strip native Java classes from the binding lib
+Build artefact optimizer of Xamarin.Forms or Xamarin.Android might strip native Java classes from the binding lib.
+This happens when `Link SDK assemblies only` option is selected for the `Linker Behaviour` settings entry.
+See the logs example below.
+
+### TL;DR; Add `proguard.cfg` file to your android app project with the following text:
+```
+-keep class com.cossacklabs.themis.**
+-keep class com.cossacklabs.themis.** {*;}
+```
+Make sure that it has a `ProguardConfiguration` build step.
+
+
+The issue could not be reproduced on this demo project yet. However, a larger commercial project had it for the same `.cproj` settings of both themis bindings and android app project. 
 For example:
 ```
 Java.Lang.IncompatibleClassChangeError: no non-static method "Lcom/cossacklabs/themis/SecureCellSeal;.decrypt([B[B)[B"
@@ -48,12 +62,21 @@ Java.Lang.IncompatibleClassChangeError: no non-static method "Lcom/cossacklabs/t
 [orion.mobile]    --- End of inner exception stack trace ---
 ```
 
-Most relevant resources for troubleshooting found so far:
+**More info** can be found in the following **github issue** of the `cossacklabs/themis` repository:
+https://github.com/cossacklabs/themis/issues/716
+
+
+Useful articles that helped troubleshooting:
 * https://gist.github.com/JonDouglas/dda6d8ace7d071b0e8cb
 * https://stackoverflow.com/questions/38967851/missing-methods-and-classes-in-jar-after-building-xamarin-app
+* https://medium.com/androiddevelopers/troubleshooting-proguard-issues-on-android-bce9de4f8a74
+* https://blog.mindorks.com/things-to-care-while-using-proguard-in-android-application
+* https://blog.mindorks.com/r8-vs-proguard-in-android
+* https://www.jon-douglas.com/2017/04/13/linker-bitdiffer/
+
 
 ---
 
 ☕ Buy me a coffee <br>
 With ETH 🔸: 0xD961220f3C356Bee7E7905377fE9Da95DE6F978E <br>
-With BTC ₿: bc1qte94s9smlzy8k0jxlfzp7pzkdx9xzztnngcg4n
+With BTC ₿: bc1qhjm5d62rysuh5rmylpstuvpgtat67v9xv0edtm

--- a/app/ThemisDemoXamarin.Android/ThemisDemoXamarin.Android.csproj
+++ b/app/ThemisDemoXamarin.Android/ThemisDemoXamarin.Android.csproj
@@ -105,5 +105,8 @@
       <Name>themis.droid.wrapper</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <ProguardConfiguration Include="proguard.cfg" />
+  </ItemGroup>
  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>

--- a/app/ThemisDemoXamarin.Android/ThemisDemoXamarin.Android.csproj
+++ b/app/ThemisDemoXamarin.Android/ThemisDemoXamarin.Android.csproj
@@ -30,7 +30,7 @@
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AndroidLinkMode>None</AndroidLinkMode>
+<MandroidI18n>cjk;mideast;other;rare;west</MandroidI18n>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/app/ThemisDemoXamarin.Android/proguard.cfg
+++ b/app/ThemisDemoXamarin.Android/proguard.cfg
@@ -1,0 +1,8 @@
+﻿
+-dontwarn com.samsung.**
+-keep class com.samsung.** {*;}
+
+
+-keep class com.cossacklabs.themis.**
+-keep class com.cossacklabs.themis.** {*;}
+

--- a/lib-bindings/themis/themis.droid.wrapper/CellSealBuilderDroid.cs
+++ b/lib-bindings/themis/themis.droid.wrapper/CellSealBuilderDroid.cs
@@ -29,6 +29,10 @@ namespace Themis.Droid
             {
                 throw new ThemisXamarinBridgeException(
                     message: "[FAIL] [droid] CellSealBuilderDroid.BuildCellSealForMasterKey()",
+                    dataAsHex: null,
+                    contextAsHex: null,
+                    dataAsBase64: null,
+                    contextAsBase64: null,
                     inner: ex);
             }
         }

--- a/lib-bindings/themis/themis.droid.wrapper/CellSealBuilderDroid.cs
+++ b/lib-bindings/themis/themis.droid.wrapper/CellSealBuilderDroid.cs
@@ -55,8 +55,8 @@ namespace Themis.Droid
 
             var wrappedStreamData =
                 new SecureCellData(
-                    protectedData: cipherTextStreamBytes,
-                    additionalData: null);
+                    /*protectedData:*/ cipherTextStreamBytes,
+                    /*additionalData:*/ null);
 
             var result = new SecureCellDataDroid(cipherTextHandle: null);
             return result;
@@ -68,8 +68,8 @@ namespace Themis.Droid
 
             var wrappedStreamData =
                 new SecureCellData(
-                    protectedData: cipherTextData,
-                    additionalData: null);
+                    /*protectedData:*/ cipherTextData,
+                    /*additionalData:*/ null);
 
             var result = new SecureCellDataDroid(cipherTextHandle: wrappedStreamData);
             return result;

--- a/lib-bindings/themis/themis.droid.wrapper/CellSealDroid.cs
+++ b/lib-bindings/themis/themis.droid.wrapper/CellSealDroid.cs
@@ -18,6 +18,10 @@ namespace Themis.Droid
             {
                 throw new ThemisXamarinBridgeException(
                     message: "[FAIL] [droid] SecureCell java constructor failed",
+                    dataAsHex: null,
+                    contextAsHex: null,
+                    dataAsBase64: null,
+                    contextAsBase64: null,
                     inner: ex);
             }
         }
@@ -78,6 +82,10 @@ namespace Themis.Droid
             {
                 throw new ThemisXamarinBridgeException(
                     message: "[FAIL] [droid] SecureCell.Unprotect() java method failed",
+                    dataAsHex: ConvertUtilsPortable.ByteArrayToHexString(cipherTextBytes),
+                    contextAsHex: ConvertUtilsPortable.ByteArrayToHexString(context),
+                    dataAsBase64: Convert.ToBase64String(cipherTextBytes),
+                    contextAsBase64: Convert.ToBase64String(context),
                     inner: ex);
             }
         }
@@ -100,6 +108,10 @@ namespace Themis.Droid
             {
                 throw new ThemisXamarinBridgeException(
                     message: "[FAIL] [droid] SecureCell.Protect() java method failed",
+                    dataAsHex: null, // avoid leaking plain text in logs
+                    contextAsHex: ConvertUtilsPortable.ByteArrayToHexString(context), // seems ok to log context
+                    dataAsBase64: null, // avoid leaking plain text in logs
+                    contextAsBase64: Convert.ToBase64String(context),
                     inner: ex);
             }
         }

--- a/lib-bindings/themis/themis.droid.wrapper/CellSealDroid.cs
+++ b/lib-bindings/themis/themis.droid.wrapper/CellSealDroid.cs
@@ -48,7 +48,7 @@ namespace Themis.Droid
             if (cipherTextData == null) throw new ArgumentNullException(nameof(cipherTextData));
 
             byte[] cipherTextBytes;
-            var managedCipherTextData = cipherTextData as SecureCellDataMock;
+            var managedCipherTextData = cipherTextData as SecureCellDataManaged;
             var droidCipherTextData = cipherTextData as SecureCellDataDroid;
 
 
@@ -63,7 +63,7 @@ namespace Themis.Droid
             else
             {
                 throw new ArgumentException(
-                    message: $"Type mismatch: {cipherTextData.GetType()} received. Expected: [ {typeof(SecureCellDataDroid)} ; {typeof(SecureCellDataMock)} ] ",
+                    message: $"Type mismatch: {cipherTextData.GetType()} received. Expected: [ {typeof(SecureCellDataDroid)} ; {typeof(SecureCellDataManaged)} ] ",
                     paramName: nameof(cipherTextData));
             }
 
@@ -92,7 +92,7 @@ namespace Themis.Droid
             {
                 byte[] cipherText = _secureCell.Encrypt(plainTextData, context);
 
-                var result = new SecureCellDataMock(cipherText);
+                var result = new SecureCellDataManaged(cipherText);
 
                 return result;
             }

--- a/lib-bindings/themis/themis.droid.wrapper/SecureCellDataDroid.cs
+++ b/lib-bindings/themis/themis.droid.wrapper/SecureCellDataDroid.cs
@@ -45,6 +45,10 @@ namespace Themis.Droid
             {
                 throw new ThemisXamarinBridgeException(
                     message: "[FAIL] [droid] SecureCellData.GetProtectedData() java method failed",
+                    dataAsHex: null,
+                    contextAsHex: null,
+                    dataAsBase64: null,
+                    contextAsBase64: null,
                     inner: ex);
             }
         }

--- a/lib-bindings/themis/themis.ios.wrapper/CellContextImprintIos.cs
+++ b/lib-bindings/themis/themis.ios.wrapper/CellContextImprintIos.cs
@@ -61,6 +61,10 @@ namespace Themis.iOS
             {
                 throw new ThemisXamarinBridgeException(
                     message: "[FAILED] TSCellContextImprint.WrapData()",
+                    dataAsHex: null,
+                    contextAsHex: null,
+                    dataAsBase64: null,
+                    contextAsBase64: null,
                     inner: ex);
             }
 

--- a/lib-bindings/themis/themis.ios.wrapper/CellSealBuilderIos.cs
+++ b/lib-bindings/themis/themis.ios.wrapper/CellSealBuilderIos.cs
@@ -32,6 +32,10 @@ namespace Themis.iOS
             {
                 throw new ThemisXamarinBridgeException(
                     message: "[FAIL] [iOS] CellSealBuilderIos.BuildCellSealForMasterKey()",
+                    dataAsHex: null,
+                    contextAsHex: null,
+                    dataAsBase64: null,
+                    contextAsBase64: null,
                     inner: ex);
             }
         }

--- a/lib-bindings/themis/themis.ios.wrapper/CellSealIos.cs
+++ b/lib-bindings/themis/themis.ios.wrapper/CellSealIos.cs
@@ -67,7 +67,7 @@ namespace Themis.iOS
             {
                 plainTextData =
                     _implCellSeal.UnwrapData(
-                        message: castedCipherTextData.cipherText,
+                        message: castedCipherTextData.CipherText,
                         context: nsContextData,
                         error: out themisError);
             }

--- a/lib-bindings/themis/themis.ios.wrapper/CellSealIos.cs
+++ b/lib-bindings/themis/themis.ios.wrapper/CellSealIos.cs
@@ -39,6 +39,10 @@ namespace Themis.iOS
             {
                 throw new ThemisXamarinBridgeException(
                     message: "TSCellSeal constructor has failed",
+                    dataAsHex: null,
+                    contextAsHex: null,
+                    dataAsBase64: null,
+                    contextAsBase64: null,
                     inner: ex);
             }
         }
@@ -75,6 +79,10 @@ namespace Themis.iOS
             {
                 throw new ThemisXamarinBridgeException(
                     message: "TSCellSeal.UnwrapData() has failed",
+                    dataAsHex: ConvertUtilsPortable.ByteArrayToHexString(cipherTextData.GetEncryptedData()),
+                    contextAsHex: ConvertUtilsPortable.ByteArrayToHexString(context),
+                    dataAsBase64: Convert.ToBase64String(cipherTextData.GetEncryptedData()),
+                    contextAsBase64: Convert.ToBase64String(context),
                     inner: ex);
             }
 
@@ -114,6 +122,10 @@ namespace Themis.iOS
             {
                 throw new ThemisXamarinBridgeException(
                     message: "TSCellSeal.WrapData() has failed",
+                    dataAsHex: null, // to avoid leaking plain text
+                    contextAsHex: ConvertUtilsPortable.ByteArrayToHexString(context),
+                    dataAsBase64: null, // to avoid leaking plain text
+                    contextAsBase64: Convert.ToBase64String(context),
                     inner: ex);
             }
 

--- a/lib-bindings/themis/themis.ios.wrapper/SecureCellDataIos.cs
+++ b/lib-bindings/themis/themis.ios.wrapper/SecureCellDataIos.cs
@@ -8,7 +8,7 @@ namespace Themis.iOS
 {
     public class SecureCellDataIos: ISecureCellData
     {
-        public NSData cipherText => _cipherText;
+        public NSData CipherText => _cipherText;
 
         public SecureCellDataIos(
             NSData cipherText,

--- a/lib-bindings/themis/themis.pcl/CellSealBuilderMock.cs
+++ b/lib-bindings/themis/themis.pcl/CellSealBuilderMock.cs
@@ -22,12 +22,12 @@ namespace Themis
 
         public ISecureCellData BuildCipherText(byte[] cipherTextData)
         {
-            return new SecureCellDataMock(rawData: cipherTextData);
+            return new SecureCellDataManaged(rawData: cipherTextData);
         }
 
         public ISecureCellData BuildCipherTextFromStream(Stream cipherTextStream)
         {
-            return new SecureCellDataMock(rawDataStream: cipherTextStream);
+            return new SecureCellDataManaged(rawDataStream: cipherTextStream);
         }
 
         public ICellContextImprint BuildImprintKdfForMasterKey(byte[] masterKeyData)

--- a/lib-bindings/themis/themis.pcl/CellSealMock.cs
+++ b/lib-bindings/themis/themis.pcl/CellSealMock.cs
@@ -28,14 +28,14 @@ namespace Themis
         {
             // no encryption since it's a mock
             // -
-            return new SecureCellDataMock(plainTextData);
+            return new SecureCellDataManaged(plainTextData);
         }
 
         public ISecureCellData WrapDataStream(Stream plainTextStream, Stream contextStream = null)
         {
             // no encryption since it's a mock
             // -
-            return new SecureCellDataMock(plainTextStream);
+            return new SecureCellDataManaged(plainTextStream);
         }
     }
 }

--- a/lib-bindings/themis/themis.pcl/ConvertUtilsPortable.cs
+++ b/lib-bindings/themis/themis.pcl/ConvertUtilsPortable.cs
@@ -82,5 +82,16 @@ namespace Themis
 
             return result;
         }
+
+        public static string ByteArrayToHexString(byte[] data)
+        {
+            if (data == null)
+            {
+                return null;
+            }
+
+            string result = BitConverter.ToString(data).Replace("-", string.Empty);
+            return result;
+        }
     }
 }

--- a/lib-bindings/themis/themis.pcl/ConvertUtilsPortable.cs
+++ b/lib-bindings/themis/themis.pcl/ConvertUtilsPortable.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.IO;
 
 

--- a/lib-bindings/themis/themis.pcl/SecureCellDataManaged.cs
+++ b/lib-bindings/themis/themis.pcl/SecureCellDataManaged.cs
@@ -3,14 +3,14 @@
 
 namespace Themis
 {
-    public class SecureCellDataMock: ISecureCellData
+    public class SecureCellDataManaged: ISecureCellData
     {
-        public SecureCellDataMock(byte[] rawData)
+        public SecureCellDataManaged(byte[] rawData)
         {
             _rawData = rawData;
         }
 
-        public SecureCellDataMock(Stream rawDataStream)
+        public SecureCellDataManaged(Stream rawDataStream)
         {
             _rawData = ConvertUtilsPortable.StreamToByteArray(rawDataStream);
         }

--- a/lib-bindings/themis/themis.pcl/ThemisXamarinBridgeException.cs
+++ b/lib-bindings/themis/themis.pcl/ThemisXamarinBridgeException.cs
@@ -5,6 +5,12 @@ namespace Themis
 {
     public class ThemisXamarinBridgeException: PlatformNotSupportedException
     {
+        public string DataAsHex { get; private set; }
+        public string ContextAsHex { get; private set; }
+
+        public string DataAsBase64 { get; private set; }
+        public string ContextAsBase64 { get; private set; }
+
         public ThemisXamarinBridgeException(): base()
         {
         }
@@ -22,9 +28,18 @@ namespace Themis
 
         public ThemisXamarinBridgeException(
             string message,
+            string dataAsHex,
+            string contextAsHex,
+            string dataAsBase64,
+            string contextAsBase64,
             Exception inner)
         : base(message, inner)
         {
+            DataAsHex = dataAsHex;
+            ContextAsHex = contextAsHex;
+
+            DataAsBase64 = dataAsBase64;
+            ContextAsBase64 = contextAsBase64;
         }
     }
 

--- a/lib-bindings/themis/themis.pcl/themis.pcl.csproj
+++ b/lib-bindings/themis/themis.pcl/themis.pcl.csproj
@@ -4,4 +4,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
Basically solved by adding `proguard.cfg` with the following test. 

```
-keep class com.cossacklabs.themis.**
-keep class com.cossacklabs.themis.** {*;}
```

Discussions in `cossacklabs/themis` repositoruy issue
https://github.com/cossacklabs/themis/issues/716